### PR TITLE
get token from function instead of file run

### DIFF
--- a/src/managers/accountManager.js
+++ b/src/managers/accountManager.js
@@ -1,8 +1,13 @@
 const _url = "http://localhost:8000"
-const token = `Token ${JSON.parse(localStorage.getItem("gondor_token")).token}`
+//const token = `Token ${JSON.parse(localStorage.getItem("gondor_token")).token}`
+
+const getToken = () =>
+{
+    return `Token ${JSON.parse(localStorage.getItem("gondor_token")).token}`
+}
 
 export const getAccountDetailsForCurrentUser = () => {
-    return fetch(`${_url}/users/me`, {headers: {Authorization: token}}).then((res => {
+    return fetch(`${_url}/users/me`, {headers: {Authorization: getToken()}}).then((res => {
         if (res.status !== 201) {
             return res.json()
         }


### PR DESCRIPTION
If you don't already have gondor token in your local storage, the token variable in account manager will throw an error. This fixes that by getting the token from a function instead.